### PR TITLE
updated bootstrap Makefile to accept custom container name

### DIFF
--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -3,6 +3,7 @@ MAKEFILE_DIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
 DOCKERFILE?=Dockerfile
 DOCKER_LABEL?=localhost/ocp-installer:latest
+CONTAINER_NAME?=ocp-installer
 
 MOTD=files/etc/motd
 
@@ -42,4 +43,4 @@ run: $(DOCKERFILE)
 	D_HOME=`$(SUDO) docker run --rm -i $(DOCKER_LABEL) /bin/sh -c 'echo $$HOME'`
 	test -z "$$D_HOME" && err 'Unable to determine docker container HOME directory'
 	V+=" -v $$T/.ssh:$$D_HOME/.ssh:Z"
-	$(SUDO) docker run --name=ocp-installer --rm -it $$V $(DOCKER_LABEL)
+	$(SUDO) docker run --name=$(CONTAINER_NAME) --rm -it $$V $(DOCKER_LABEL)


### PR DESCRIPTION
Needed for demos, you can create two install containers, and one can be used as a pre-created backup for when the demo doesn't go as planned. Also need to add this to the inventory file if you're creating two demo environments.

```ini
ec2_tags={"demo": "ocp-backup", "Name": "{{ inventory_hostname }}"}
```